### PR TITLE
Fix 'bukkit:' prefix bypass

### DIFF
--- a/src/main/java/net/noodles/pl/nopluginscommand/NoPluginsCommand.java
+++ b/src/main/java/net/noodles/pl/nopluginscommand/NoPluginsCommand.java
@@ -26,7 +26,7 @@ public final class NoPluginsCommand extends JavaPlugin implements Listener {
     @EventHandler
     public void onCommandUse(PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
-        List<String> commands = Arrays.asList("pl", "about", "version", "ver", "plugins", "minecraft:pl", "minecraft:plugins", "minecraft:about", "minecraft:version", "minecaft:ver");
+        List<String> commands = Arrays.asList("pl", "about", "version", "ver", "plugins", "bukkit:pl", "bukkit:about", "bukkit:version", "bukkit:ver", "bukkit:plugins", "minecraft:pl", "minecraft:plugins", "minecraft:about", "minecraft:version", "minecraft:ver");
         commands.forEach(all -> {
          if (event.getMessage().toLowerCase().equalsIgnoreCase("/" + all.toLowerCase())) {
              event.setCancelled(true);


### PR DESCRIPTION
Fixed so players are blocked from accessing the plugins using the "bukkit:" prefix, also fixed a typo in another command.

Version bump not included.