### PR TITLE
Update NoPluginsCommand.java

### DIFF
--- a/src/main/java/net/noodles/pl/nopluginscommand/NoPluginsCommand.java
+++ b/src/main/java/net/noodles/pl/nopluginscommand/NoPluginsCommand.java
@@ -27,7 +27,8 @@ public final class NoPluginsCommand extends JavaPlugin implements Listener {
     public void onCommandUse(PlayerCommandPreprocessEvent event) {
         List<String> commands = Arrays.asList("?", "pl", "about", "version", "ver", "plugins", "bukkit:?", "bukkit:pl", "bukkit:about", "bukkit:version", "bukkit:ver", "bukkit:plugins", "minecraft:pl", "minecraft:plugins", "minecraft:about", "minecraft:version", "minecraft:ver");
         commands.forEach(all -> {
-         if (event.getMessage().toLowerCase().equalsIgnoreCase("/" + all.toLowerCase())) {
+         String[] arrCommand = event.getMessage().toLowerCase().split(" ", 2);
+         if (arrCommand[0].equalsIgnoreCase("/" + all.toLowerCase())) {
              event.setCancelled(true);
          }
         });


### PR DESCRIPTION
Split message on spaces, then only check 1st element of result against blocked command list. Fixes '/plugins a' or other arguments bypassing blocked commands.

Fixes #3 