### PR TITLE
fix #9: legacy api version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,4 @@ main: net.noodles.pl.nopluginscommand.NoPluginsCommand
 authors: [BGHDDevelopmentLLC]
 description: Blocks /plugin, /about, /version, and more!
 website: https://bghddevelopment.com
+api-version: 1.18


### PR DESCRIPTION
Fixes #9:

```
[21:55:06 ERROR]: [STDERR] [org.bukkit.craftbukkit.v1_18_R2.legacy.CraftLegacy] Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
[21:55:09 WARN]: Legacy plugin NoPluginsCommand v1.1-SNAPSHOT does not specify an api-version.
```
